### PR TITLE
Add the ability to remove or replace image on an entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stream2Blog: a text-based user interface for microblogging into a macroblog
 
-There is a Rust-based UI built on [Ratatui](https://ratatui.rs/), backed by an Elixir/Phoenix/SQLite storage app. It works on my machine. (MacOS, tested with iTerm2, GhosTTY and the VS Code terminal.)
+This is a Rust-based UI built on [Ratatui](https://ratatui.rs/), backed by an Elixir/Phoenix/SQLite storage app. It works on my machine. (MacOS, tested with iTerm2, GhosTTY and the VS Code terminal.)
 
 Images are displayed with [Ratatui-image](https://github.com/benjajaja/ratatui-image).
 

--- a/rust_tui/src/app.rs
+++ b/rust_tui/src/app.rs
@@ -33,6 +33,7 @@ pub struct App {
     pub entry_thumbnails: std::collections::HashMap<String, ImagePreview>, // Cached thumbnails by entry_id
     pub current_entry_image_path: Option<String>, // Track image path for current entry
     pub original_entry_content: Option<String>, // Store original content when editing entry
+    pub original_entry_image_path: Option<String>, // Store original image path when editing entry
     pub wrap_width: usize, // Centralized wrap width for consistent text wrapping
     pub last_resize_time: Option<Instant>, // Track last resize event for debouncing
     pub resize_debounce_ms: u64, // Debounce duration in milliseconds
@@ -70,6 +71,7 @@ impl App {
             entry_thumbnails: std::collections::HashMap::new(),
             current_entry_image_path: None,
             original_entry_content: None,
+            original_entry_image_path: None,
             wrap_width: 80, // Default wrap width, will be updated based on terminal size
             last_resize_time: None,
             resize_debounce_ms: 100, // 100ms debounce for resize events

--- a/rust_tui/src/editor_views.rs
+++ b/rust_tui/src/editor_views.rs
@@ -371,6 +371,55 @@ impl App {
         log::debug!("Image naming modal fully rendered");
     }
 
+    pub fn draw_image_replacement_modal(&mut self, f: &mut Frame, prev_state: &AppState) {
+        log::debug!("draw_image_replacement_modal called with prev_state: {prev_state:?}");
+        
+        // Draw the previous state in the background
+        match prev_state {
+            AppState::CreateThread => self.draw_create_thread(f),
+            AppState::EditThread(_) => self.draw_edit_thread(f),
+            AppState::CreateEntry(_) => self.draw_create_entry(f),
+            AppState::EditEntry(_, _) => self.draw_edit_entry(f),
+            _ => {} // Other states don't need background
+        }
+
+        // Draw modal popup
+        let popup_area = centered_rect_fixed_height(60, 8, f.area());
+        f.render_widget(Clear, popup_area);
+        
+        // Add background with warning styling
+        let background = Block::default()
+            .borders(Borders::ALL)
+            .title("Image Already Exists")
+            .style(Style::default().fg(Color::Yellow));
+        f.render_widget(background, popup_area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // Top padding
+                Constraint::Length(2), // Message text
+                Constraint::Length(1), // Separator
+                Constraint::Length(2), // Options
+                Constraint::Length(1), // Bottom padding
+            ])
+            .split(popup_area);
+
+        // Message text
+        let message = Paragraph::new("This entry already has an image attached.\nWhat would you like to do?")
+            .alignment(Alignment::Center)
+            .style(Style::default());
+        f.render_widget(message, popup_chunks[1]);
+
+        // Options
+        let options = Paragraph::new("[R] Replace   [D] Delete Current   [Esc] Cancel")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Cyan));
+        f.render_widget(options, popup_chunks[3]);
+
+        log::debug!("Image replacement modal fully rendered");
+    }
+
     pub fn draw_character_limit_error_modal(&mut self, f: &mut Frame, prev_state: &AppState) {
         log::debug!(
             "draw_character_limit_error_modal called with prev_state: {prev_state:?}"

--- a/rust_tui/src/editor_views.rs
+++ b/rust_tui/src/editor_views.rs
@@ -420,6 +420,54 @@ impl App {
         log::debug!("Image replacement modal fully rendered");
     }
 
+    pub fn draw_image_removal_modal(&mut self, f: &mut Frame, prev_state: &AppState) {
+        log::debug!("draw_image_removal_modal called with prev_state: {prev_state:?}");
+        
+        // Draw the previous state in the background
+        match prev_state {
+            AppState::CreateThread => self.draw_create_thread(f),
+            AppState::EditThread(_) => self.draw_edit_thread(f),
+            AppState::CreateEntry(_) => self.draw_create_entry(f),
+            AppState::EditEntry(_, _) => self.draw_edit_entry(f),
+            _ => {} // Other states don't need background
+        }
+
+        // Draw modal popup
+        let popup_area = centered_rect_fixed_height(60, 7, f.area());
+        f.render_widget(Clear, popup_area);
+        
+        // Add background with warning styling
+        let background = Block::default()
+            .borders(Borders::ALL)
+            .title("Remove Image")
+            .style(Style::default().fg(Color::Red));
+        f.render_widget(background, popup_area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // Top padding
+                Constraint::Length(2), // Message text
+                Constraint::Length(1), // Separator
+                Constraint::Length(2), // Options
+            ])
+            .split(popup_area);
+
+        // Message text
+        let message = Paragraph::new("Are you sure you want to remove this image?\nThis action cannot be undone.")
+            .alignment(Alignment::Center)
+            .style(Style::default());
+        f.render_widget(message, popup_chunks[1]);
+
+        // Options
+        let options = Paragraph::new("[Y] Yes, Remove   [N] No   [Esc] Cancel")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Cyan));
+        f.render_widget(options, popup_chunks[3]);
+
+        log::debug!("Image removal modal fully rendered");
+    }
+
     pub fn draw_character_limit_error_modal(&mut self, f: &mut Frame, prev_state: &AppState) {
         log::debug!(
             "draw_character_limit_error_modal called with prev_state: {prev_state:?}"

--- a/rust_tui/src/handlers.rs
+++ b/rust_tui/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use crate::image_clip::save_image_with_context;
+use crate::image_clip::{save_image_with_context, delete_image_file};
 use crate::key_handler::KeyResult;
 use crate::state::AppState;
 use chrono::{DateTime, Utc};
@@ -209,40 +209,64 @@ impl App {
     }
 
     fn transition_to_image_naming(&mut self, image_data: Vec<u8>) {
-        log::debug!("ImageNamingModal result received, transitioning to ImageNaming state");
+        log::debug!("ImageNamingModal result received, checking for existing image");
 
-        // Extract previous state
-        let prev_state = match &self.state {
-            AppState::CreateThread => AppState::CreateThread,
-            AppState::CreateEntry(id) => AppState::CreateEntry(id.clone()),
-            AppState::EditEntry(t_id, e_id) => AppState::EditEntry(t_id.clone(), e_id.clone()),
-            _ => AppState::CreateThread, // fallback
-        };
+        // Check if there's already an image for this entry
+        if let Some(current_image_path) = self.get_current_image_path() {
+            log::debug!("Existing image found: {}, showing replacement modal", current_image_path);
+            
+            // Extract previous state
+            let prev_state = match &self.state {
+                AppState::CreateThread => AppState::CreateThread,
+                AppState::CreateEntry(id) => AppState::CreateEntry(id.clone()),
+                AppState::EditEntry(t_id, e_id) => AppState::EditEntry(t_id.clone(), e_id.clone()),
+                _ => AppState::CreateThread, // fallback
+            };
 
-        log::debug!(
-            "Previous state: {:?}, image data length: {} bytes",
-            prev_state,
-            image_data.len()
-        );
+            // Save current text editor content before transitioning
+            self.saved_text_content = Some(self.text_editor.lines().join("\n"));
 
-        // Save current text editor content before transitioning
-        self.saved_text_content = Some(self.text_editor.lines().join("\n"));
+            // Transition to ConfirmImageReplacement state
+            self.state = AppState::ConfirmImageReplacement(Box::new(prev_state), image_data, current_image_path);
+            self.mark_dirty();
 
-        // Transition to ImageNaming state
-        self.state = AppState::ImageNaming(Box::new(prev_state), image_data);
+            log::debug!("State changed to ConfirmImageReplacement");
+        } else {
+            log::debug!("No existing image, proceeding with normal image naming flow");
+            
+            // Extract previous state
+            let prev_state = match &self.state {
+                AppState::CreateThread => AppState::CreateThread,
+                AppState::CreateEntry(id) => AppState::CreateEntry(id.clone()),
+                AppState::EditEntry(t_id, e_id) => AppState::EditEntry(t_id.clone(), e_id.clone()),
+                _ => AppState::CreateThread, // fallback
+            };
 
-        log::debug!("State changed to ImageNaming");
+            log::debug!(
+                "Previous state: {:?}, image data length: {} bytes",
+                prev_state,
+                image_data.len()
+            );
 
-        // Clear and setup modal text editor for filename input
-        self.modal_text_editor.clear();
-        self.modal_text_editor.set_block(
-            ratatui::widgets::Block::default()
-                .borders(ratatui::widgets::Borders::ALL)
-                .title("Enter filename"),
-        );
-        self.mark_dirty();
+            // Save current text editor content before transitioning
+            self.saved_text_content = Some(self.text_editor.lines().join("\n"));
 
-        log::debug!("Text editor cleared and block set for filename input");
+            // Transition to ImageNaming state
+            self.state = AppState::ImageNaming(Box::new(prev_state), image_data);
+
+            log::debug!("State changed to ImageNaming");
+
+            // Clear and setup modal text editor for filename input
+            self.modal_text_editor.clear();
+            self.modal_text_editor.set_block(
+                ratatui::widgets::Block::default()
+                    .borders(ratatui::widgets::Borders::ALL)
+                    .title("Enter filename"),
+            );
+            self.mark_dirty();
+
+            log::debug!("Text editor cleared and block set for filename input");
+        }
     }
 
     fn setup_text_editor_block(&mut self) {
@@ -1052,6 +1076,91 @@ impl App {
                     }
                 }
             }
+            AppState::ConfirmImageReplacement(prev_state, image_data, current_image_path) => {
+                match key.code {
+                    KeyCode::Char('r') | KeyCode::Char('R') => {
+                        // Replace the current image
+                        log::debug!("User chose to replace existing image");
+                        
+                        // Delete the old image file
+                        if let Err(e) = delete_image_file(current_image_path) {
+                            log::warn!("Failed to delete old image file: {e}");
+                        }
+                        
+                        // Clone necessary data before state change
+                        let prev_state_clone = (**prev_state).clone();
+                        let image_data_clone = image_data.clone();
+                        
+                        // Transition to ImageNaming state for the new image
+                        self.state = AppState::ImageNaming(Box::new(prev_state_clone), image_data_clone);
+                        
+                        // Clear and setup modal text editor for filename input
+                        self.modal_text_editor.clear();
+                        self.modal_text_editor.set_block(
+                            ratatui::widgets::Block::default()
+                                .borders(ratatui::widgets::Borders::ALL)
+                                .title("Enter filename"),
+                        );
+                        log::debug!("Transitioned to ImageNaming for replacement");
+                    }
+                    KeyCode::Char('d') | KeyCode::Char('D') => {
+                        // Delete/remove the current image without replacing
+                        log::debug!("User chose to delete/remove existing image");
+                        
+                        // Delete the old image file
+                        if let Err(e) = delete_image_file(current_image_path) {
+                            log::warn!("Failed to delete old image file: {e}");
+                        }
+                        
+                        // Clear the current entry's image path
+                        self.current_entry_image_path = None;
+                        
+                        // Restore previous state and text content
+                        let prev_state_clone = (**prev_state).clone();
+                        self.state = prev_state_clone;
+                        
+                        // Restore saved text content
+                        if let Some(saved_content) = &self.saved_text_content {
+                            self.text_editor.set_text(saved_content);
+                        }
+                        
+                        // Clear image preview
+                        self.text_editor.image_preview_mut().clear();
+                        
+                        // Setup text editor based on previous state
+                        self.setup_text_editor_block();
+                        
+                        // Clear saved content
+                        self.saved_text_content = None;
+                        
+                        log::debug!("Image removed and returned to previous state");
+                    }
+                    KeyCode::Esc => {
+                        // Cancel - don't replace or delete, just go back
+                        log::debug!("User cancelled image replacement");
+                        
+                        // Restore previous state and text content
+                        let prev_state_clone = (**prev_state).clone();
+                        self.state = prev_state_clone;
+                        
+                        // Restore saved text content
+                        if let Some(saved_content) = &self.saved_text_content {
+                            self.text_editor.set_text(saved_content);
+                        }
+                        
+                        // Clear saved content
+                        self.saved_text_content = None;
+                        
+                        // Restore text editor block title based on previous state
+                        self.setup_text_editor_block();
+                        
+                        log::debug!("Cancelled and returned to previous state");
+                    }
+                    _ => {
+                        // Ignore other keys
+                    }
+                }
+            }
             AppState::CharacterLimitError(prev_state) => {
                 match key.code {
                     KeyCode::Enter | KeyCode::Esc => {
@@ -1130,6 +1239,10 @@ impl App {
                     self.mark_dirty();
                     return Ok(());
                 }
+            }
+            AppState::ConfirmImageReplacement(_, _, _) => {
+                // For image replacement modal, ignore mouse events
+                return Ok(());
             }
             AppState::CharacterLimitError(_) => {
                 // For character limit error modal, ignore mouse events
@@ -1257,6 +1370,10 @@ impl App {
             AppState::ImageNaming(_, _) => {
                 // Mouse events for image naming modal are handled by the text editor
                 log::debug!("Mouse click in image naming modal handled by text editor");
+            }
+            AppState::ConfirmImageReplacement(_, _, _) => {
+                // Ignore mouse events in image replacement modal - only keyboard input accepted
+                log::debug!("Mouse click in image replacement modal ignored");
             }
             AppState::CharacterLimitError(_) => {
                 // Ignore mouse events in character limit error modal - only keyboard input accepted
@@ -1395,5 +1512,14 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    pub fn get_current_image_path(&self) -> Option<String> {
+        match &self.state {
+            AppState::CreateEntry(_) | AppState::EditEntry(_, _) => {
+                self.current_entry_image_path.clone()
+            }
+            _ => None
+        }
     }
 }

--- a/rust_tui/src/image_clip.rs
+++ b/rust_tui/src/image_clip.rs
@@ -83,3 +83,17 @@ pub fn save_image_with_context(
 
     Ok(relative_path)
 }
+
+pub fn delete_image_file(image_path: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let current_dir = std::env::current_dir()?;
+    let full_path = current_dir.join(image_path);
+    
+    if full_path.exists() {
+        fs::remove_file(&full_path)?;
+        log::info!("Successfully deleted image file: {}", image_path);
+    } else {
+        log::warn!("Image file not found, skipping deletion: {}", image_path);
+    }
+    
+    Ok(())
+}

--- a/rust_tui/src/key_handler.rs
+++ b/rust_tui/src/key_handler.rs
@@ -8,12 +8,14 @@ pub struct KeyHandler;
 pub enum KeyResult {
     Handled(bool),
     ImageNamingModal(Vec<u8>), // Image data for naming modal
+    ImageRemovalModal, // Show image removal modal for existing image
 }
 
 impl KeyHandler {
     pub fn handle_clipboard_keys(
         textarea: &mut TextArea<'static>,
         key: KeyEvent,
+        has_existing_image: bool,
     ) -> Option<KeyResult> {
         // log::debug!("handle_clipboard_keys called with key: {:?}", key);
         match (key.code, key.modifiers) {
@@ -193,7 +195,13 @@ impl KeyHandler {
                     }
                     Err(e) => {
                         log::error!("Failed to get image from clipboard: {e}");
-                        Some(KeyResult::Handled(false))
+                        if has_existing_image {
+                            log::debug!("No clipboard image but entry has existing image, showing removal modal");
+                            Some(KeyResult::ImageRemovalModal)
+                        } else {
+                            log::debug!("No clipboard image and no existing image, operation failed");
+                            Some(KeyResult::Handled(false))
+                        }
                     }
                 }
             }

--- a/rust_tui/src/state.rs
+++ b/rust_tui/src/state.rs
@@ -12,5 +12,6 @@ pub enum AppState {
     ConfirmDiscardNewEntry(String), // thread_id
     ImageNaming(Box<AppState>, Vec<u8>), // previous_state, image_data
     ConfirmImageReplacement(Box<AppState>, Vec<u8>, String), // previous_state, new_image_data, current_image_path
+    ConfirmImageRemoval(Box<AppState>, String), // previous_state, current_image_path
     CharacterLimitError(Box<AppState>), // previous_state
 }

--- a/rust_tui/src/state.rs
+++ b/rust_tui/src/state.rs
@@ -11,5 +11,6 @@ pub enum AppState {
     ConfirmDiscardEntryChanges(String, String), // thread_id, entry_id
     ConfirmDiscardNewEntry(String), // thread_id
     ImageNaming(Box<AppState>, Vec<u8>), // previous_state, image_data
+    ConfirmImageReplacement(Box<AppState>, Vec<u8>, String), // previous_state, new_image_data, current_image_path
     CharacterLimitError(Box<AppState>), // previous_state
 }

--- a/rust_tui/src/text_editor.rs
+++ b/rust_tui/src/text_editor.rs
@@ -199,16 +199,23 @@ impl TextEditor {
         log::debug!("TextEditor received key event: {key:?}");
 
         // Handle clipboard operations first (especially image paste)
-        if let Some(result) = KeyHandler::handle_clipboard_keys(&mut self.textarea, key) {
+        let has_existing_image = self.has_image();
+        if let Some(result) = KeyHandler::handle_clipboard_keys(&mut self.textarea, key, has_existing_image) {
             match &result {
                 KeyResult::ImageNamingModal(_) => {
                     log::debug!("Clipboard operation result: ImageNamingModal with image data")
+                }
+                KeyResult::ImageRemovalModal => {
+                    log::debug!("Clipboard operation result: ImageRemovalModal for existing image")
                 }
                 other => log::debug!("Clipboard operation result: {other:?}"),
             }
             match result {
                 KeyResult::ImageNamingModal(image_data) => {
                     return Some(KeyResult::ImageNamingModal(image_data));
+                }
+                KeyResult::ImageRemovalModal => {
+                    return Some(KeyResult::ImageRemovalModal);
                 }
                 KeyResult::Handled(true) => {
                     // Successful clipboard operation handled

--- a/rust_tui/src/ui.rs
+++ b/rust_tui/src/ui.rs
@@ -30,6 +30,10 @@ impl App {
                 log::debug!("Drawing ImageNaming modal, prev_state: {prev_state:?}");
                 self.draw_image_naming_modal(f, prev_state);
             }
+            AppState::ConfirmImageReplacement(prev_state, _, _) => {
+                log::debug!("Drawing ConfirmImageReplacement modal, prev_state: {prev_state:?}");
+                self.draw_image_replacement_modal(f, prev_state);
+            }
             AppState::CharacterLimitError(prev_state) => {
                 log::debug!("Drawing CharacterLimitError modal, prev_state: {prev_state:?}");
                 self.draw_character_limit_error_modal(f, prev_state);

--- a/rust_tui/src/ui.rs
+++ b/rust_tui/src/ui.rs
@@ -34,6 +34,10 @@ impl App {
                 log::debug!("Drawing ConfirmImageReplacement modal, prev_state: {prev_state:?}");
                 self.draw_image_replacement_modal(f, prev_state);
             }
+            AppState::ConfirmImageRemoval(prev_state, _) => {
+                log::debug!("Drawing ConfirmImageRemoval modal, prev_state: {prev_state:?}");
+                self.draw_image_removal_modal(f, prev_state);
+            }
             AppState::CharacterLimitError(prev_state) => {
                 log::debug!("Drawing CharacterLimitError modal, prev_state: {prev_state:?}");
                 self.draw_character_limit_error_modal(f, prev_state);

--- a/rust_tui/vibe-coding_a_blogging_app_in_rust_and_elixir.md
+++ b/rust_tui/vibe-coding_a_blogging_app_in_rust_and_elixir.md
@@ -1,0 +1,110 @@
+# Vibe-coding a blogging app in Rust and Elixir
+
+Writing is hard. Late one night, reflecting on how I'd effortlessly plopped the highlights of a hike, with photos, into a Slack thread, I had the punch-drunk inspiration to find out if a similar combination of constraints and conveniences could help with other kinds of writing.
+
+Feeling good about Claude and Claude Code, I decided to put my pants on my head and make it a CLI (later upgraded to TUI), in Rust.
+
+Further, because Parenthesis II app is an Elixir front end for state that lives in a Rust program, I liked the symmetry of this being a Rust "front end" with the data persisted by an Elixir app. Also, for the record: Claude assured me that this was a brilliant design.
+
+I had some requirements in mind for the working product.
+
+* it should work on Mac, because that's where I am. 
+* the experience overall should be much like composing messages in Bluesky or Slack 
+* entries would be limited in length and there'd be a character count display 
+* it should be easy to attach an image to an entry 
+* we're not learning Vim or Emacs keys
+
+I didn't know if those were all doable.
+
+In Claude Code's plan mode, I got a fairly involved design doc for a minimal version of the Rust bit, using the ratatui TUI library, and the Elixir bit for storing state in SQLite using Ecto. I got a slight API mismatch out of asking Claude to implement them separately, but since clearing that up, there's been basically nothing to say about the Elixir/Ecto/SQLite side. It's pretty simple and Claude basically one-shotted it.
+
+Except, (particularly) if you're developing your app while populating your database, don't forget to back up anything you may want to keep that could get stomped on in a bad migration.
+
+
+Prior to this, passing my eyeballs over some of Corrosion's source code was just about all my Rust experience, and I really didn't know where to start. Claude generated a small thing that did something, and the great thing then is that I suddenly had Rust code. I could start asking LLMs to explain it function by function, or line by line, and it wasn't a hello world; i actually cared what it did.
+
+Interstitial thought: noisy logging may eat more tokens than needed, and pollute the context?
+
+
+Some observations
+
+* I wanted mouse interaction, particularly in the editor. 
+* Claude struggles with counting the lines and columns in a Ratatui block. 
+* You need an offset to account for the border and/or padding of the block.
+
+_Implementing word wrap is hard. Complicated. Error-prone._  Don't do it if you don't have to (like if you can use an existing library).
+
+
+
+## Using Rust
+
+I wanted to touch Rust but not too much. How much would I learn, and how much would an LLM-based process insulate me from learning?
+
+## Word wrapping
+
+Of the things I took for granted from browser-based interfaces, and there were a few, soft-wrapping in a textarea is probably the biggest deal for me here. Stubbornness is why this is a TUI app, but stubbornness is also why I didn't want to compromise on wrapping OR mouse support.
+
+I really wanted to try making something I can use. And to use it, I need to be thinking as little as possible about the mechanics of entering content.
+
+There's no word wrapping in tui-textarea. It uses the Paragraph widget, which does have wrapping but doesn't give you access to the resulting lines (I think). Which are helpful for things like scrolling or arrow-keying through screen lines.
+
+There's an existing editor crate with wrapping: edtui; but it's very invested in Vim, and while I did test the waters for adapting it, overriding that preference got complicated and I changed tack.
+
+
+
+ If there were, it would mess with one of my other fussy requirements: using the mouse to edit text. We need the cursor to land on the visual position of the characters we aimed the mouse at. Ratatui's Paragraph widget does handle soft wrapping, but the mouse position doesn't know what character is where.s. In menus that use Paragraph, I decided just not to wrap.
+
+
+
+I couldn't do without some wrapping in the text editor, though. I decided to try an adaptive hard wrap. This was very difficult with Claude, at least using the angles I tried. I had a hard time (read: failed, several times) keeping it from adding complications every time I interacted with it until I had to start over. Honestly, Claude has, or I gave it, weird ideas about how this seemingly simple (if repetitive) process should work.
+
+Wrapping is pretty good but a WIP.
+
+Writing is hard. This article alone took days of programming.
+
+I built myself some constraints and some conveniences. I've been noodling on this post as I've gone along; word wrapping was far and away the biggest pit I fell into, and the app was pretty usable early on. But my mind was more urgently on the app than on the writing. Even now, I'm thinking about the rough edges.
+ 
+
+![Image](images/threads/5c29294d-dd67-47e7-891e-6b454d80a960/e7cab497-a64a-47fc-98bc-bd9b2e351a88/hey.png)
+
+Even if I've guessed the right combo of constraints and convenience, did I build in a fatal flaw in the very fact that I'm aware of imperfections and have the power to fix them? If I don't ever just use it, 
+
+I have been able to live in an uneasy peace with bugs in my other homemade tools, so it's possible. It's an important 
+
+
+
+## Elixir?
+
+It's not entirely arbitrary. My blog runs on Elixir. There's no reason my Rust program couldn't own its own SQLite database, I can move a slider to put the boundary between the blog and the Rust app wherever I like. 
+
+My initial reasoning had to do with the fact that I'm comfortable working with Phoenix and Ecto and would be better able to debug schema and db things there. As it turned out, Claude is comfy with them too, and I have hardly had to look at that side of the app.
+
+I'm putting a screenshot in this so I can show off images.
+
+![Image](images/threads/5c29294d-dd67-47e7-891e-6b454d80a960/screenie.png)
+
+## Keybindings
+
+We can't use Enter with  modifiers. You get around that in JS using `preventDefault`. Here, I'm just using Ctrl+s to save edits.
+
+In iTerm2, to move the cursor one word left or right with alt+left/right through settings -> profiles -> keys -> key bindings -> presets -> natural text editing
+
+In Ghostty this seems to be the default.
+
+
+## Images
+
+It was important to me that I be able to add images with very little effort. The truth is, with LLMs it'll be very easy to add a step that resizes or whatever if I can get the image loaded. But I want, straight away, to have some stupid-simple way to add an image to an entry. Ideally: paste from the OS clipboard.
+
+I was having the thread view UI load each entry's image (if any) and size it to fit the widget space on demand. I'm trying to brute-force this, not get too fancy, but this was too slow.
+
+I compromised: when you load a "thread", it loads, resizes (if needed), and caches all that thread's entries' images.
+
+So loading the thread is noticeably laggy. But on my Macbook, switching between entries with previews or opening the editor with one is comfortable.
+
+## Other compromises
+
+* Can't select text in the vanilla Paragraph widget, so where I'm using that, you...can't select text. This isn't entirely surprising in an interface developed without the mouse in mind.
+
+* Because of the circuitous route I took to composing this, there'll be inefficiencies, inconsistencies, and magic numbers.
+


### PR DESCRIPTION
ctrl+p can 

* add an image from the clipboard to an entry
* replace the entry image from the OS clipboard (with confirmation)
* remove the entry image (with confirmation)

When an image is removed, it's removed from disk and the image cache, and the image reference for that thread entry removed.